### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,6 @@
-Soon
+All informations on contributing can be found on the [corresponding wiki page.](https://github.com/iScsc/wiresmash/wiki/Contributing) Read at least the general policies section, and specific sections. 
+
+Quick TLDR:
+- To contribute, do fork-branch-PR.
+- To report bugs, make sure not to create duplicates and create an issue with as many information as possible. Name it `bug-xxx`.
+- For feature requests, make an issue named `request-xxx`


### PR DESCRIPTION
Should close #10, since I have updated the [wiki page.](https://github.com/iScsc/wiresmash/wiki/Contributing)